### PR TITLE
adding quotes to port names so hashes dont error

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -101,7 +101,7 @@ class Edge {
     Object.entries(node).forEach(([key, value]) => {
       if (key !== "node") {
         if (value) {
-          output += ":" + value;
+          output += ':"' + value + '"';
         }
       }
     });


### PR DESCRIPTION
Wraps portname in quotes. Was having an issue when graphviz went to convert the dot file to pdf, it read thee portname as a number (not string) if the portname started with a number. This fix resolves the issue.